### PR TITLE
Handle the scene changes in client

### DIFF
--- a/Client/config/scenes/firstScene.json
+++ b/Client/config/scenes/firstScene.json
@@ -2,7 +2,7 @@
     "keyBinds": [
         {
             "key": "KEY_APOSTROPHE",
-            "path" : ""
+            "path" : "testScene.json"
         },
         {
             "key": "KEY_COMMA",
@@ -11,7 +11,6 @@
     ],
     "entities": [
         [
-
         ]
     ],
     "systems": [

--- a/Client/config/scenes/testScene.json
+++ b/Client/config/scenes/testScene.json
@@ -1,14 +1,14 @@
 {
-  "keyBinds": [
-    {
-      "key": "KEY_COMMA",
-      "path" : ""
-    }
-  ],
-  "entities": [
-    [
+    "keyBinds": [
+        {
+            "key": "KEY_COMMA",
+            "path" : ""
+        }
+    ],
+    "entities": [
+        [
+        ]
+    ],
+    "systems": [
     ]
-  ],
-  "systems": [
-  ]
 }

--- a/Client/src/Application/Application.cpp
+++ b/Client/src/Application/Application.cpp
@@ -11,8 +11,6 @@
 Application::Application()
 {
     _registries = std::make_shared<std::vector<ECS::Registry>>();
-    ECS::Registry reg;
-    _registries.get()->push_back(reg);
     SceneManager::ClientSceneManager sceneManager(_registries);
     // Initialize the network and the first scene
 }

--- a/Client/src/ClientSceneManager/ClientSceneManager.hpp
+++ b/Client/src/ClientSceneManager/ClientSceneManager.hpp
@@ -70,6 +70,13 @@ namespace SceneManager {
             void _loadScene(const std::string &path, std::size_t index);
 
             /**
+             * @brief Load the next scenes of a already loaded scene.
+             * @param path Path to the json file.
+             * @param index Index of the registry to load the scene.
+             */
+            void _loadNextScenes(const std::string &path, std::size_t index);
+
+            /**
              * @brief Load the components of a scene.
              * @param root Json root of the scene.
              * @param index Index of the registry to load the scene.
@@ -90,5 +97,11 @@ namespace SceneManager {
              */
             void _loadSceneKeys(Json::Value root, std::size_t index);
 
+            /**
+             * @brief Change the current scene.
+             * @param scene Scene to load.
+             * @param key Key to load the scene.
+             */
+            void _changeScene(std::pair<std::size_t, std::string> scene, KEY_MAP key);
     };
 }

--- a/Client/src/ClientSceneManager/ClientSceneManager.hpp
+++ b/Client/src/ClientSceneManager/ClientSceneManager.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <unordered_map>
-
 #include <json/json.h>
 
 #include "ISystem.hpp"
 #include "StringKeyMap.hpp"
+#include "interfaces/ISceneManager.hpp"
 
 #define FIRST_SCENE "firstScene.json"
 #define SCENE_PATH "Client/config/scenes/"
@@ -20,7 +20,12 @@
 #define LIB_SYSTEMS_PATH "Client/lib/systems/"
 
 #define CONFIG_SUFFIX ".json"
-#define LIB_SUFFIX ".so"
+
+#ifdef _WIN32
+    #define LIB_SUFFIX ".dll"
+#else
+    #define LIB_SUFFIX ".so"
+#endif
 
 /**
  * @brief Namespace for the scene manager.
@@ -52,9 +57,10 @@ namespace SceneManager {
         private:
 
             std::shared_ptr<std::vector<ECS::Registry>> _registries; // Registries for each scene
-            std::vector<std::unordered_map<KEY_MAP, std::shared_ptr<ISystem>>> _keysRegistry; // Keys of each scene
+            std::vector<std::unordered_map<KEY_MAP, std::shared_ptr<ISystem>>> _keysSystems; // Keys to load a system for each scene
+            std::vector<std::unordered_map<KEY_MAP, std::pair<std::size_t, std::string>>> _keysScenes; // Keys to load a scene for each scene
 
-            std::size_t _registerIndex; // Index of the current registry
+            std::size_t _nextIndex; // Index of the next empty registry
 
             /**
              * @brief Load a scene from a json file.


### PR DESCRIPTION
I handled the scene swaps, and I also fixed an issue with the index management.

The issue was that all the next scenes were load at the previous scene index.

---
Now let's dive into an example of a scene swap:

In a list of scenes [0 (current), 1 (previous), 2 (next), 3, 4, 5, ...], if we want to go to the scene 4, we'll need to

Swap the scene 4 with the previous scene(1)

Then we have this:
[0  (current), 4 (previous), 2 (next), 3, 1, 5, ...]

Then swap the current with the previous and have this:
[4 (current), 0 (previous), 2 (next), 3, 1, 5, ...]

Then clear all the old next scenes, and got this:
[4, (current), 0 (previous)]

Then load all the new next scenes 👍   