### PR TITLE
refactor(SceneManager): change the way Entities are init by running a…

### DIFF
--- a/Engine/Client/Src/Application/Application.cpp
+++ b/Engine/Client/Src/Application/Application.cpp
@@ -36,5 +36,6 @@ void Application::run()
 
     while (libGraphic->windowIsOpen()) {
         libGraphic->clear();
+        _registries->at(SceneManager::RegisterIndex::CURRENT).run_systems(-1);
     }
 }

--- a/Engine/Shared/SceneManager/ASceneManager.hpp
+++ b/Engine/Shared/SceneManager/ASceneManager.hpp
@@ -93,11 +93,11 @@ namespace SceneManager {
             void _loadNextScenes(const std::string &path, std::size_t index);
 
             /**
-             * @brief Load the components of a scene.
+             * @brief Load the entities of a scene.
              * @param root Json root of the scene.
              * @param index Index of the registry to load the scene.
              */
-            void _loadSceneComponents(Json::Value root, std::size_t index);
+            void _loadSceneEntities(Json::Value root, std::size_t index);
 
             /**
              * @brief Load the systems of a scene.


### PR DESCRIPTION
It is now more simple to initialize an Entity in a configuration file.
You just have to write one .so system to init your entity.

Here an example of a config file to init two players:
![image](https://github.com/user-attachments/assets/2d94e5f4-be3a-4f5d-b1ab-a07e0f76a05d)

