### PR TITLE
FEAT: Create drawTextureRect system and textureRectComponent

### DIFF
--- a/Engine/Client/CMakeLists.txt
+++ b/Engine/Client/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SYSTEM_SRC_FILE
     ${EXE_SRC_PATH}/Systems/DrawOBJ/DrawOBJSystem.cpp
     ${EXE_SRC_PATH}/Systems/DrawTexture/DrawTextureSystem.cpp
     ${EXE_SRC_PATH}/Systems/DrawText/DrawTextSystem.cpp
+    ${EXE_SRC_PATH}/Systems/DrawTextureRect/DrawTextureRectSystem.cpp
 )
 
 # Define the main source files for the executable

--- a/Engine/Client/CMakeLists.txt
+++ b/Engine/Client/CMakeLists.txt
@@ -20,6 +20,7 @@ set(COMPONENT_SRC_FILE
     ../Shared/Component/FontPathComponent.cpp
     ../Shared/Component/ObjPathComponent.cpp
     ../Shared/Component/TexturePathComponent.cpp
+    ../Shared/Component/TextureRectComponent.cpp
     ../Shared/Component/ScaleComponent.cpp
     ../Shared/Component/ColourComponent.cpp
     ../Shared/Component/Position3DComponent.cpp

--- a/Engine/Client/Src/Application/Application.cpp
+++ b/Engine/Client/Src/Application/Application.cpp
@@ -30,6 +30,7 @@ void Application::_initDefaultGraphicSystems()
     _defaultSystems.push_back(DrawOBJSystem().getFunction());
     _defaultSystems.push_back(DrawTextureSystem().getFunction());
     _defaultSystems.push_back(DrawTextSystem().getFunction());
+    _defaultSystems.push_back(DrawTextureRectSystem().getFunction());
 }
 
 void Application::_keyboardHandler(std::size_t key)

--- a/Engine/Client/Src/Application/Application.hpp
+++ b/Engine/Client/Src/Application/Application.hpp
@@ -16,8 +16,9 @@
 #include "ClientSceneManager.hpp"
 #include "GetGraphicalLibrary.hpp"
 #include "DrawOBJ/DrawOBJSystem.hpp"
-#include "DrawTexture/DrawTextureSystem.hpp"
 #include "DrawText/DrawTextSystem.hpp"
+#include "DrawTexture/DrawTextureSystem.hpp"
+#include "DrawTextureRect/DrawTextureRectSystem.hpp"
 
 #define WINDOW_TITLE "From noware"
 

--- a/Engine/Client/Src/Systems/DrawTextureRect/DrawTextureRectSystem.cpp
+++ b/Engine/Client/Src/Systems/DrawTextureRect/DrawTextureRectSystem.cpp
@@ -1,0 +1,49 @@
+/*
+** EPITECH PROJECT, 2024
+** DrawTextureRectSystem
+** File description:
+** DrawTextureRectSystem
+*/
+
+#include "DrawTextureRectSystem.hpp"
+#include "Position2DComponent.hpp"
+#include "ScaleComponent.hpp"
+#include "TextureRectComponent.hpp"
+#include "GetGraphicalLibrary.hpp"
+#include "SparseArray.hpp"
+
+#include <exception>
+
+DrawTextureRectSystem::DrawTextureRectSystem() :
+    ASystem("DrawTextureRectSystem")
+{
+}
+
+void DrawTextureRectSystem::_drawTextureRect(ECS::Registry& reg, int idxPacketEntities)
+{
+    std::shared_ptr<IGraphic> libGraphic = getGraphicalLibrary();
+
+    ECS::SparseArray<IComponent> texturerectComponents = reg.get_components<IComponent>("TextureRectComponent");
+    ECS::SparseArray<IComponent> position2DComponents = reg.get_components<IComponent>("Position2DComponent");
+    ECS::SparseArray<IComponent> scaleComponents = reg.get_components<IComponent>("ScaleComponent");
+
+    for (ECS::entity_t entity = 0; texturerectComponents.size() >= entity + 1; entity++) {
+        std::shared_ptr<TextureRectComponent> texture = std::dynamic_pointer_cast<TextureRectComponent>(texturerectComponents[entity]);
+        if (!texture)
+            continue;
+
+        std::shared_ptr<Position2DComponent> pos = (position2DComponents.size() >= entity + 1) ?
+            std::dynamic_pointer_cast<Position2DComponent>(position2DComponents[entity]) : nullptr;
+
+        std::shared_ptr<ScaleComponent> scale = (scaleComponents.size() >= entity + 1) ?
+            std::dynamic_pointer_cast<ScaleComponent>(scaleComponents[entity]) : nullptr;
+
+        float modelScale;
+
+        modelScale = (scale) ? scale->scale : 1.0;
+        if (pos)
+            libGraphic->drawTextureRect(texture->path, pos->x, pos->y, texture->left, texture->top, texture->width, texture->height, modelScale);
+        else
+            libGraphic->drawTextureRect(texture->path, 0, 0, texture->left, texture->top, texture->width, texture->height, modelScale);
+    }
+}

--- a/Engine/Client/Src/Systems/DrawTextureRect/DrawTextureRectSystem.hpp
+++ b/Engine/Client/Src/Systems/DrawTextureRect/DrawTextureRectSystem.hpp
@@ -1,0 +1,49 @@
+/*
+** EPITECH PROJECT, 2024
+** DrawTextureRectSystem
+** File description:
+** DrawTextureRectSystem
+*/
+
+#pragma once
+
+#include <iostream>
+
+#include "ISystem.hpp"
+
+/**
+ * @brief System to draw an Texture Rect.
+ *
+ */
+class DrawTextureRectSystem : public ASystem {
+
+    public:
+
+        /**
+         * @brief Construct a new Draw Texture Rect System object.
+         *
+         */
+        DrawTextureRectSystem();
+
+        /**
+         * @brief Destroy the Draw Texture Rect System object.
+         *
+         */
+        ~DrawTextureRectSystem() = default;
+
+        /**
+         * @brief Get the Function object.
+         *
+         * @return std::function<void(ECS::Registry& reg, int idxPacketEntities)>
+         */
+        std::function<void(ECS::Registry& reg, int idxPacketEntities)> getFunction()
+        {
+            return [this](ECS::Registry& reg, int idxPacketEntities) {
+                _drawTextureRect(reg, idxPacketEntities);
+            };
+        }
+
+    private:
+
+        void _drawTextureRect(ECS::Registry& reg, int idxPacketEntities); //< Function to draw texture rect.
+};

--- a/Engine/Server/CMakeLists.txt
+++ b/Engine/Server/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRC_EXE
     ../Shared/Component/FontPathComponent.cpp
     ../Shared/Component/ObjPathComponent.cpp
     ../Shared/Component/TexturePathComponent.cpp
+    ../Shared/Component/TextureRectComponent.cpp
     ../Shared/Component/ScaleComponent.cpp
     ../Shared/Component/ColourComponent.cpp
     ../Shared/Component/Position3DComponent.cpp

--- a/Engine/Shared/Component/TextureRectComponent.cpp
+++ b/Engine/Shared/Component/TextureRectComponent.cpp
@@ -7,5 +7,5 @@
 
 #include "TextureRectComponent.hpp"
 
-TextureRectComponent::TextureRectComponent(std::string path, int left, int top, int width, int height) :
+TextureRectComponent::TextureRectComponent(std::string path, float left, float top, float width, float height) :
     AComponent("TextureRectComponent"), path(path), left(left), top(top), width(width), height(height) {}

--- a/Engine/Shared/Component/TextureRectComponent.cpp
+++ b/Engine/Shared/Component/TextureRectComponent.cpp
@@ -1,0 +1,11 @@
+/*
+** EPITECH PROJECT, 2024
+** TextureRectComponent.cpp
+** File description:
+** DESCRIPTION
+*/
+
+#include "TextureRectComponent.hpp"
+
+TextureRectComponent::TextureRectComponent(std::string path, int left, int top, int width, int height) :
+    AComponent("TextureRectComponent"), path(path), left(left), top(top), width(width), height(height) {}

--- a/Engine/Shared/Component/TextureRectComponent.hpp
+++ b/Engine/Shared/Component/TextureRectComponent.hpp
@@ -22,10 +22,10 @@ class TextureRectComponent : public AComponent {
     public:
 
         std::string path; //< The path to one file.
-        int left; //< Left coordinate of the rectangle.
-        int top; //< Top coordinate of the rectangle.
-        int width; //< Width of the rectangle.
-        int height; //< Height of the rectangle.
+        float left; //< Left coordinate of the rectangle.
+        float top; //< Top coordinate of the rectangle.
+        float width; //< Width of the rectangle.
+        float height; //< Height of the rectangle.
 
         /**
          * @brief Construct a new TextureRectComponent object
@@ -36,5 +36,5 @@ class TextureRectComponent : public AComponent {
          * @param width Width of the rectangle.
          * @param height Height of the rectangle.
          */
-        TextureRectComponent(std::string Path = "", int left = 0, int top = 0, int width = 0, int height = 0);
+        TextureRectComponent(std::string Path = "", float left = 0, float top = 0, float width = 0, float height = 0);
 };

--- a/Engine/Shared/Component/TextureRectComponent.hpp
+++ b/Engine/Shared/Component/TextureRectComponent.hpp
@@ -1,0 +1,40 @@
+/*
+** EPITECH PROJECT, 2024
+** TextureRectComponent.hpp
+** File description:
+** DESCRIPTION
+*/
+
+#pragma once
+
+#include "IComponent.hpp"
+#include "SFML/Graphics.hpp"
+
+/**
+ * @class TextureRectComponent
+ * @brief Component for handling Texture Rect in the graphical engine.
+ *
+ * This component is used to store and manage texture rect for the graphical engine.
+ *
+ * @var Path The path to one file.
+ */
+class TextureRectComponent : public AComponent {
+    public:
+
+        std::string path; //< The path to one file.
+        int left; //< Left coordinate of the rectangle.
+        int top; //< Top coordinate of the rectangle.
+        int width; //< Width of the rectangle.
+        int height; //< Height of the rectangle.
+
+        /**
+         * @brief Construct a new TextureRectComponent object
+         *
+         * @param Path Initial path to the font file (default is an empty string).
+         * @param left Left coordinate of the rectangle.
+         * @param top Top coordinate of the rectangle.
+         * @param width Width of the rectangle.
+         * @param height Height of the rectangle.
+         */
+        TextureRectComponent(std::string Path = "", int left = 0, int top = 0, int width = 0, int height = 0);
+};

--- a/Engine/Shared/Component/TextureRectComponent.hpp
+++ b/Engine/Shared/Component/TextureRectComponent.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include "IComponent.hpp"
-#include "SFML/Graphics.hpp"
 
 /**
  * @class TextureRectComponent

--- a/Engine/Shared/Interface/IGraphic.hpp
+++ b/Engine/Shared/Interface/IGraphic.hpp
@@ -79,6 +79,20 @@ class IGraphic {
         virtual void drawTexture(std::string texturePath, float posx, float posy, float scale) = 0;
 
         /**
+         * @brief Draw a texture rect on the screen.
+         *
+         * @param texturePath Path to the Texture to draw.*
+         * @param posx Position x.
+         * @param posy Position y.
+         * @param left Left coordinate of the rectangle.
+         * @param top Top coordinate of the rectangle.
+         * @param width Width of the rectangle.
+         * @param height Height of the rectangle.
+         * @param scale Scale.
+         */
+        virtual void drawTextureRect(std::string texturePath, float posx, float posy, float left, float top, float width, float height, float scale) = 0;
+
+        /**
          * @brief Draw a text on the screen.
          *
          * @param text Text to draw.

--- a/Engine/Shared/SceneManager/ASceneManager.cpp
+++ b/Engine/Shared/SceneManager/ASceneManager.cpp
@@ -168,4 +168,5 @@ void SceneManager::ASceneManager::_initialiseDefaultComponents()
     _defaultRegistry.register_component<IComponent>(SoundVolumeComponent().getType());
     _defaultRegistry.register_component<IComponent>(TextComponent().getType());
     _defaultRegistry.register_component<IComponent>(TexturePathComponent().getType());
+    _defaultRegistry.register_component<IComponent>(TextureRectComponent().getType());
 }

--- a/Engine/Shared/SceneManager/ASceneManager.hpp
+++ b/Engine/Shared/SceneManager/ASceneManager.hpp
@@ -29,6 +29,7 @@
 #include "MusicVolumeComponent.hpp"
 #include "SoundVolumeComponent.hpp"
 #include "TexturePathComponent.hpp"
+#include "TextureRectComponent.hpp"
 
 #define CONFIG_SUFFIX ".json"
 

--- a/GraphicLibrary/Src/GraphicLib.cpp
+++ b/GraphicLibrary/Src/GraphicLib.cpp
@@ -73,6 +73,18 @@ void GraphicLib::drawTexture(std::string texturePath, float posx, float posy, fl
     DrawTextureEx(_textures[texturePath], position, 0, scale, WHITE);
 }
 
+void GraphicLib::drawTextureRect(std::string texturePath, float posx, float posy, float left, float top, float width, float height, float scale)
+{
+    if (_textures.find(texturePath) == _textures.end())
+        _textures[texturePath] = LoadTexture(texturePath.c_str());
+
+    Rectangle rect = {left, top, width, height};
+    Rectangle rectDest = {posx, posy, width * scale, height * scale};
+    Vector2 origin = { 0, 0 };
+
+    DrawTexturePro(_textures[texturePath], rect, rectDest, origin, 0, WHITE);
+}
+
 void GraphicLib::drawText(std::string text, float posx, float posy, int fontSize, std::string fontPath,
     unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {

--- a/GraphicLibrary/Src/GraphicLib.hpp
+++ b/GraphicLibrary/Src/GraphicLib.hpp
@@ -46,7 +46,7 @@ class GraphicLib : public IGraphic {
          * @brief Check if the window is open.
          *
          * @return true The window is open.
-         * @return false The window is closed.                                     /
+         * @return false The window is closed.
          */
         bool windowIsOpen();
 
@@ -77,12 +77,26 @@ class GraphicLib : public IGraphic {
         /**
          * @brief Draw a texture on the screen.
          *
-         * @param texturePath Path to the Texture to draw.*
+         * @param texturePath Path to the Texture to draw.
          * @param posx Position x
          * @param posy Position y
          * @param scale Scale.
          */
         void drawTexture(std::string texturePath, float posx, float posy, float scale);
+
+        /**
+         * @brief Draw a texture rect on the screen.
+         *
+         * @param texturePath Path to the Texture to draw.
+         * @param posx Position x.
+         * @param posy Position y.
+         * @param left Left coordinate of the rectangle.
+         * @param top Top coordinate of the rectangle.
+         * @param width Width of the rectangle.
+         * @param height Height of the rectangle.
+         * @param scale Scale.
+         */
+        void drawTextureRect(std::string texturePath, float posx, float posy, float left, float top, float width, float height, float scale);
 
         /**
          * @brief Draw a text on the screen.


### PR DESCRIPTION
I created a TextureRectComponent and a drawTextureRectSystem to draw a rectangle of a texture on the screen.
With this image:
![r-typesheet42](https://github.com/user-attachments/assets/3dc6e738-a24e-48fe-941c-234a4f82c751)
I can draw only this:
![image](https://github.com/user-attachments/assets/265bd93b-c3ff-4f1e-87e2-5ce36b279ddb)
