### PR TITLE
FIX: Fix input catching in client

### DIFF
--- a/Engine/Client/CMakeLists.txt
+++ b/Engine/Client/CMakeLists.txt
@@ -34,6 +34,7 @@ set(COMPONENT_SRC_FILE
     ../Shared/Component/SoundPathComponent.cpp
     ../Shared/Component/SoundPitchComponent.cpp
     ../Shared/Component/SoundVolumeComponent.cpp
+    ../Shared/Component/Entities/Player/PlayerComponent.cpp
 )
 
 # Define system source files

--- a/Engine/Client/Src/Network/NetworkClient.cpp
+++ b/Engine/Client/Src/Network/NetworkClient.cpp
@@ -16,6 +16,7 @@ Network::Client::Client(const std::string& server_ip, int tcp_port, int udp_port
     _tcp_socket = std::make_shared<asio::ip::tcp::socket>(*_io_context);
     _udp_socket = std::make_shared<asio::ip::udp::socket>(*_io_context);
     _messageId = 0x0000;
+    _token = 0;
 }
 
 void Network::Client::connect(MessageHandler callback, ECS::Registry& reg)

--- a/Engine/Server/CMakeLists.txt
+++ b/Engine/Server/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRC_EXE
     ../Shared/Component/SoundPathComponent.cpp
     ../Shared/Component/SoundPitchComponent.cpp
     ../Shared/Component/SoundVolumeComponent.cpp
+    ../Shared/Component/Entities/Player/PlayerComponent.cpp
 )
 
 # Include directories for header files
@@ -56,6 +57,7 @@ include_directories(
     ../Shared/Network/Packet
     ../Shared/Component
     ../Shared/Component/Entities
+    ../Shared/Component/Entities/Player
     ${EXE_INCLUDE_PATH}
 )
 

--- a/Engine/Shared/Ecs/Src/SparseArray.hpp
+++ b/Engine/Shared/Ecs/Src/SparseArray.hpp
@@ -101,7 +101,7 @@ class SparseArray {
          */
         SparseArray &operator=(SparseArray const &other)
         {
-            _data = other.data;
+            _data = other._data;
             return *this;
         };
 

--- a/Engine/Shared/SceneManager/ASceneManager.cpp
+++ b/Engine/Shared/SceneManager/ASceneManager.cpp
@@ -169,4 +169,5 @@ void SceneManager::ASceneManager::_initialiseDefaultComponents()
     _defaultRegistry.register_component<IComponent>(TextComponent().getType());
     _defaultRegistry.register_component<IComponent>(TexturePathComponent().getType());
     _defaultRegistry.register_component<IComponent>(TextureRectComponent().getType());
+    _defaultRegistry.register_component<IComponent>(PlayerComponent().getType());
 }

--- a/Engine/Shared/SceneManager/ASceneManager.hpp
+++ b/Engine/Shared/SceneManager/ASceneManager.hpp
@@ -30,6 +30,7 @@
 #include "SoundVolumeComponent.hpp"
 #include "TexturePathComponent.hpp"
 #include "TextureRectComponent.hpp"
+#include "PlayerComponent.hpp"
 
 #define CONFIG_SUFFIX ".json"
 

--- a/GraphicLibrary/Src/GraphicLib.cpp
+++ b/GraphicLibrary/Src/GraphicLib.cpp
@@ -45,7 +45,7 @@ void GraphicLib::clear()
 
 std::size_t GraphicLib::getKeyInput() {
     for (std::size_t i = KEY_NULL; i < KEY_KP_EQUAL; i++) {
-        if (IsKeyPressed(i))
+        if (IsKeyDown(i))
             return i;
     }
     return KEY_NULL;

--- a/GraphicLibrary/Src/GraphicLib.cpp
+++ b/GraphicLibrary/Src/GraphicLib.cpp
@@ -45,7 +45,7 @@ void GraphicLib::clear()
 
 std::size_t GraphicLib::getKeyInput() {
     for (std::size_t i = KEY_NULL; i < KEY_KP_EQUAL; i++) {
-        if (IsKeyDown(i))
+        if (IsKeyPressed(i))
             return i;
     }
     return KEY_NULL;


### PR DESCRIPTION
I fixed the user input catching. Before they were caught when a key is down, now, they're caught whenever a key is pressed.

I also fixed some scene issues, mainly caused by the client network.

The first issue was an uninitialized value.
The second is about the way the client tokens are handled, and I didn't fix it yet.

To reproduce the bug:
If you put the same entity `libsystem_initPlayerOne.so` in two linked configuration files, the spaceship of the second scene will appear in the first scene forever after swapping to the second one and coming back to the first one.