### PR TITLE
Fix: Make the Shoot Damage System opennable on windows

### DIFF
--- a/R-TypeGame/Systems/Shoot/ShootDamageSystem.cpp
+++ b/R-TypeGame/Systems/Shoot/ShootDamageSystem.cpp
@@ -104,7 +104,8 @@ void ShootDamageSystem::_shootDamage(ECS::Registry &reg, int idxPacketEntities)
     }
 }
 
-extern "C" ISystem *loadSystemInstance()
-{
-    return new ShootDamageSystem();
+extern "C" {
+    EXPORT_SYMBOL ISystem *loadSystemInstance() {
+        return new ShootDamageSystem();
+    }
 }


### PR DESCRIPTION
I added a little missed  specifier that allow windows to open the dll file of the shoot damage system