### PR TITLE
FEAT: Make server connection menu

### DIFF
--- a/Game/GameData/Scenes/Menus/Buttons/connectButtonSystem.json
+++ b/Game/GameData/Scenes/Menus/Buttons/connectButtonSystem.json
@@ -1,19 +1,19 @@
 {
     "TextureRectComponent":{
-        "path":"./Assets/Button11.png",
+        "path":"./Assets/BaseRectangleButton.png",
         "left":0,
         "top":0,
-        "width":105,
-        "height":21
+        "width":410,
+        "height":110
     },
-    "ScaleComponent":3,
+    "ScaleComponent":0.8,
     "Position2DComponent":{
         "x":800,
-        "y":515
+        "y":815
     },
     "TextPosition2DComponent":{
-        "x":845,
-        "y":535
+        "x":850,
+        "y":850
     },
     "ColourComponent":{
         "r":255,
@@ -27,8 +27,8 @@
     "FontPathComponent": "",
     "ButtonStateComponent": "NONE",
     "ButtonTexturePathComponent": {
-        "None": "./Assets/Button11.png",
-        "Hover": "./Assets/Button15.png",
-        "Clicked": "./Assets/Button16.png"
+        "None": "./Assets/BaseRectangleButton.png",
+        "Hover": "./Assets/HoverRectangleButton.png",
+        "Clicked": "./Assets/PressedRectangleButton.png"
     }
 }

--- a/Game/GameData/Scenes/Menus/Buttons/ipTextBoxSystem.json
+++ b/Game/GameData/Scenes/Menus/Buttons/ipTextBoxSystem.json
@@ -1,19 +1,19 @@
 {
     "TextureRectComponent":{
-        "path":"./Assets/Button11.png",
+        "path":"./Assets/BaseRectangleButton.png",
         "left":0,
         "top":0,
-        "width":105,
-        "height":21
+        "width":410,
+        "height":110
     },
-    "ScaleComponent":3,
+    "ScaleComponent":1,
     "Position2DComponent":{
-        "x":500,
-        "y":215
+        "x":400,
+        "y":515
     },
     "TextPosition2DComponent":{
-        "x":535,
-        "y":235
+        "x":450,
+        "y":555
     },
     "ColourComponent":{
         "r":255,
@@ -24,12 +24,12 @@
     "TextComponent": "Write the server IP",
     "TextLimitComponent": 15,
     "DefaultTextComponent": "Write the server IP",
-    "Size1DComponent": 24,
+    "Size1DComponent": 30,
     "FontPathComponent": "",
     "ButtonStateComponent": "NONE",
     "ButtonTexturePathComponent": {
-        "None": "./Assets/Button11.png",
-        "Hover": "./Assets/Button15.png",
-        "Clicked": "./Assets/Button16.png"
+        "None": "./Assets/BaseRectangleButton.png",
+        "Hover": "./Assets/HoverRectangleButton.png",
+        "Clicked": "./Assets/PressedRectangleButton.png"
     }
 }

--- a/Game/GameData/Scenes/Menus/Buttons/portTextBoxSystem.json
+++ b/Game/GameData/Scenes/Menus/Buttons/portTextBoxSystem.json
@@ -1,19 +1,19 @@
 {
     "TextureRectComponent":{
-        "path":"./Assets/Button11.png",
+        "path":"./Assets/BaseRectangleButton.png",
         "left":0,
         "top":0,
-        "width":105,
-        "height":21
+        "width":410,
+        "height":110
     },
-    "ScaleComponent":3,
+    "ScaleComponent":1,
     "Position2DComponent":{
         "x":1100,
-        "y":215
+        "y":515
     },
     "TextPosition2DComponent":{
-        "x":1125,
-        "y":235
+        "x":1135,
+        "y":555
     },
     "ColourComponent":{
         "r":255,
@@ -24,12 +24,12 @@
     "TextLimitComponent": 15,
     "TextComponent": "Write the server Port",
     "DefaultTextComponent": "Write the server Port",
-    "Size1DComponent": 24,
+    "Size1DComponent": 30,
     "FontPathComponent": "",
     "ButtonStateComponent": "NONE",
     "ButtonTexturePathComponent": {
-        "None": "./Assets/Button11.png",
-        "Hover": "./Assets/Button15.png",
-        "Clicked": "./Assets/Button16.png"
+        "None": "./Assets/BaseRectangleButton.png",
+        "Hover": "./Assets/HoverRectangleButton.png",
+        "Clicked": "./Assets/PressedRectangleButton.png"
     }
 }

--- a/Game/GameData/Scenes/Menus/Texts/serverConnectionTextSystem.json
+++ b/Game/GameData/Scenes/Menus/Texts/serverConnectionTextSystem.json
@@ -1,0 +1,15 @@
+{
+    "TextPosition2DComponent":{
+        "x":730,
+        "y":235
+    },
+    "ColourComponent":{
+        "r":255,
+        "g":255,
+        "b":255,
+        "a":255
+    },
+    "TextComponent": "Connect to a server !",
+    "Size1DComponent": 40,
+    "FontPathComponent": ""
+}

--- a/Game/GameData/Scenes/Menus/serverConnectionMenu.json
+++ b/Game/GameData/Scenes/Menus/serverConnectionMenu.json
@@ -1,0 +1,19 @@
+{
+    "keyBinds": [
+    ],
+    "entities": [
+        "libsystem_initBackground.so",
+        "libsystem_initConnectButton.so",
+        "libsystem_initIpTextButton.so",
+        "libsystem_initPortTextButton.so",
+        "libsystem_initServerConnectionText.so"
+    ],
+    "systems": [
+        "libsystem_handleMouse.so",
+        "libsystem_handleTyping.so"
+    ],
+    "menus": {
+        "keyBinds": [
+        ]
+    }
+}

--- a/R-TypeGame/Systems/AText/ATextInitSystem.cpp
+++ b/R-TypeGame/Systems/AText/ATextInitSystem.cpp
@@ -1,0 +1,46 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** AText.cpp
+*/
+
+#include "ATextInitSystem.hpp"
+#include "TextParser.hpp"
+#include "Size1DParser.hpp"
+#include "ColourParser.hpp"
+#include "FontPathParser.hpp"
+#include "TextPosition2DParser.hpp"
+
+void ATextInitSystem::_setTextProperties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath)
+{
+    std::shared_ptr<TextComponent> text = parseText(filePath);
+    if (text) {
+        reg.register_component<IComponent>(text->getType());
+        reg.set_component<IComponent>(idxPacketEntities, text, text->getType());
+    }
+
+    std::shared_ptr<FontPathComponent> font = parseFontPath(filePath);
+    if (font) {
+        reg.register_component<IComponent>(font->getType());
+        reg.set_component<IComponent>(idxPacketEntities, font, font->getType());
+    }
+
+    std::shared_ptr<Size1DComponent> size1D = parseSize1D(filePath);
+    if (size1D) {
+        reg.register_component<IComponent>(size1D->getType());
+        reg.set_component<IComponent>(idxPacketEntities, size1D, size1D->getType());
+    }
+
+    std::shared_ptr<TextPosition2DComponent> textPosition2D = parseTextPosition2D(filePath);
+    if (textPosition2D) {
+        reg.register_component<IComponent>(textPosition2D->getType());
+        reg.set_component<IComponent>(idxPacketEntities, textPosition2D, textPosition2D->getType());
+    }
+
+    std::shared_ptr<ColourComponent> colour = parseColour(filePath);
+    if (colour) {
+        reg.register_component<IComponent>(colour->getType());
+        reg.set_component<IComponent>(idxPacketEntities, colour, colour->getType());
+    }
+}

--- a/R-TypeGame/Systems/AText/ATextInitSystem.hpp
+++ b/R-TypeGame/Systems/AText/ATextInitSystem.hpp
@@ -1,0 +1,38 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** AText.hpp
+*/
+
+#pragma once
+
+#include "Registry.hpp"
+
+class ATextInitSystem {
+
+    public:
+
+        /**
+         * @brief Construct a new ATextInitSystem object
+         *
+         */
+        ATextInitSystem() = default;
+
+        /**
+         * @brief Destroy the ATextInitSystem object
+         *
+         */
+        ~ATextInitSystem() = default;
+
+    protected:
+
+        /**
+         * @brief Set the Text Properties object
+         *
+         * @param reg The registry to fill
+         * @param idxPacketEntities The index of the packet entities
+         * @param filePath The path to the json file
+         */
+        void _setTextProperties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath);
+};

--- a/R-TypeGame/Systems/CMakeLists.txt
+++ b/R-TypeGame/Systems/CMakeLists.txt
@@ -572,6 +572,7 @@ add_library(system_initMapEditorButton SHARED
 target_link_libraries(system_initMapEditorButton PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initServerConnectionText SHARED
+        ../Error/AError.cpp
         ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
         AText/ATextInitSystem.cpp
         Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.cpp

--- a/R-TypeGame/Systems/CMakeLists.txt
+++ b/R-TypeGame/Systems/CMakeLists.txt
@@ -88,6 +88,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/Engine/Shared/Enum/
     Menus/Buttons/AButton/
     ../Error/
+    ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/
+    AText/
 )
 
 # Add a shared library target 'system_initPlayer'
@@ -326,6 +328,7 @@ add_library(system_hitboxPlayer SHARED
 
 add_library(system_initIpTextButton SHARED
     ../Error/AError.cpp
+    ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
     Menus/Buttons/AButton/AButtonInitSystem.cpp
     Menus/Buttons/IpTextBox/IpTextBoxInitSystem.cpp
     ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -360,6 +363,7 @@ target_link_libraries(system_initIpTextButton PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initPortTextButton SHARED
     ../Error/AError.cpp
+    ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
     Menus/Buttons/AButton/AButtonInitSystem.cpp
     Menus/Buttons/PortTextBox/PortTextBoxInitSystem.cpp
     ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -445,6 +449,7 @@ target_link_libraries(system_initEndLogo PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initExitButton SHARED
         ../Error/AError.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
         Menus/Buttons/AButton/AButtonInitSystem.cpp
         Menus/Buttons/ExitButton/ExitButtonInitSystem.cpp
         ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -475,6 +480,7 @@ target_link_libraries(system_initExitButton PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initSingleplayerButton SHARED
         ../Error/AError.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
         Menus/Buttons/AButton/AButtonInitSystem.cpp
         Menus/Buttons/SingleplayerButton/SingleplayerButtonInitSystem.cpp
         ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -505,6 +511,7 @@ target_link_libraries(system_initSingleplayerButton PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initMultiplayerButton SHARED
         ../Error/AError.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
         Menus/Buttons/AButton/AButtonInitSystem.cpp
         Menus/Buttons/MultiplayerButton/MultiplayerButtonInitSystem.cpp
         ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -535,6 +542,7 @@ target_link_libraries(system_initMultiplayerButton PRIVATE JsonCpp::JsonCpp)
 
 add_library(system_initMapEditorButton SHARED
         ../Error/AError.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
         Menus/Buttons/AButton/AButtonInitSystem.cpp
         Menus/Buttons/MapEditorButton/MapEditorButtonInitSystem.cpp
         ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Position2D/Position2DComponent.cpp
@@ -562,3 +570,21 @@ add_library(system_initMapEditorButton SHARED
         ${CMAKE_SOURCE_DIR}/Engine/Client/Src/GetGraphicalLibrary/GetGraphicalLibrary.cpp
 )
 target_link_libraries(system_initMapEditorButton PRIVATE JsonCpp::JsonCpp)
+
+add_library(system_initServerConnectionText SHARED
+        ${CMAKE_SOURCE_DIR}/Engine/Ecs/Src/Registry.cpp
+        AText/ATextInitSystem.cpp
+        Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Text/TextComponent.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/FontPath/FontPathComponent.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Colour/ColourComponent.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Size1D/Size1DComponent.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/TextPosition2D/TextPosition2DComponent.cpp
+        ${CMAKE_SOURCE_DIR}/Engine/Shared/DefaultComponents/Draw/DrawComponent.cpp
+        ../Parser/TextPosition2DParser/TextPosition2DParser.cpp
+        ../Parser/FontPathParser/FontPathParser.cpp
+        ../Parser/TextParser/TextParser.cpp
+        ../Parser/ColourParser/ColourParser.cpp
+        ../Parser/Size1DParser/Size1DParser.cpp
+)
+target_link_libraries(system_initServerConnectionText PRIVATE JsonCpp::JsonCpp)

--- a/R-TypeGame/Systems/Menus/Buttons/AButton/AButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/AButton/AButtonInitSystem.cpp
@@ -19,10 +19,11 @@
 #include "ScaleComponent.hpp"
 #include "Size1DComponent.hpp"
 #include "ColourComponent.hpp"
-#include "AButtonInitSystem.hpp"
 #include "Position2DParser.hpp"
+#include "AButtonInitSystem.hpp"
 #include "ButtonStateParser.hpp"
 #include "TextureRectParser.hpp"
+#include "ClickableComponent.hpp"
 #include "Position2DComponent.hpp"
 #include "ButtonStateComponent.hpp"
 #include "TextureRectComponent.hpp"
@@ -31,7 +32,7 @@
 #include "ButtonTexturePathParser.hpp"
 #include "ButtonTexturePathComponent.hpp"
 
-void AButtonInitSystem::_setButtonProprieties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath, std::function<void(ECS::Registry &, int)> callback)
+void AButtonInitSystem::_setButtonProperties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath, std::function<void(ECS::Registry &, int)> callback)
 {
     std::shared_ptr<TextComponent> text = parseText(filePath);
     if (text) {

--- a/R-TypeGame/Systems/Menus/Buttons/AButton/AButtonInitSystem.hpp
+++ b/R-TypeGame/Systems/Menus/Buttons/AButton/AButtonInitSystem.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "ClickableComponent.hpp"
+#include "Registry.hpp"
 
 /**
  * @brief AButtonInitSystem class
@@ -32,12 +32,12 @@ class AButtonInitSystem {
     protected:
 
         /**
-         * @brief Set the Button Proprieties object
+         * @brief Set the Button Properties object
          *
          * @param reg The registry to fill
          * @param idxPacketEntities The index of the packet entities
          * @param filePath The path to the json file
          * @param callback The callback to set
          */
-        void _setButtonProprieties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath, std::function<void(ECS::Registry &reg, int idxPacketEntities)> callback);
+        void _setButtonProperties(ECS::Registry &reg, int idxPacketEntities, const std::string &filePath, std::function<void(ECS::Registry &reg, int idxPacketEntities)> callback);
 };

--- a/R-TypeGame/Systems/Menus/Buttons/ConnectButton/ConnectButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/ConnectButton/ConnectButtonInitSystem.cpp
@@ -19,6 +19,7 @@
 #include "ButtonStateParser.hpp"
 #include "TextureRectParser.hpp"
 #include "AButtonInitSystem.hpp"
+#include "ClickableComponent.hpp"
 #include "Position2DComponent.hpp"
 #include "TextureRectComponent.hpp"
 #include "DefaultTextComponent.hpp"
@@ -107,7 +108,7 @@ void ConnectButtonInitSystem::_initButton(ECS::Registry& reg, int idxPacketEntit
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 
     reg.register_component<IComponent>("NetworkConnectionComponent");
     reg.set_component<IComponent>(idxPacketEntities, std::make_shared<NetworkConnectionComponent>(), "NetworkConnectionComponent");

--- a/R-TypeGame/Systems/Menus/Buttons/ExitButton/ExitButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/ExitButton/ExitButtonInitSystem.cpp
@@ -37,7 +37,7 @@ void ExitButtonInitSystem::_initButton(ECS::Registry& reg, int idxPacketEntities
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 }
 
 extern "C" {

--- a/R-TypeGame/Systems/Menus/Buttons/IpTextBox/IpTextBoxInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/IpTextBox/IpTextBoxInitSystem.cpp
@@ -11,9 +11,9 @@
 #include "TextComponent.hpp"
 #include "DrawComponent.hpp"
 #include "TextLimitParser.hpp"
-#include "FontPathComponent.hpp"
 #include "EditableComponent.hpp"
 #include "DefaultTextParser.hpp"
+#include "ClickableComponent.hpp"
 #include "TextLimitComponent.hpp"
 #include "IpTextBoxInitSystem.hpp"
 #include "ButtonStateComponent.hpp"
@@ -65,7 +65,7 @@ void IpTextBoxInitSystem::_initButton(ECS::Registry& reg, int idxPacketEntities)
         handleOthers(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 
     std::shared_ptr<EditableComponent> editable = std::make_shared<EditableComponent>();
     reg.register_component<IComponent>(editable->getType());

--- a/R-TypeGame/Systems/Menus/Buttons/MapEditorButton/MapEditorButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/MapEditorButton/MapEditorButtonInitSystem.cpp
@@ -34,7 +34,7 @@ void MapEditorButtonInitSystem::_initButton(ECS::Registry& reg, int idxPacketEnt
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 }
 
 extern "C" {

--- a/R-TypeGame/Systems/Menus/Buttons/MultiplayerButton/MultiplayerButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/MultiplayerButton/MultiplayerButtonInitSystem.cpp
@@ -34,7 +34,7 @@ void MultiplayerButtonInitSystem::_initButton(ECS::Registry& reg, int idxPacketE
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 }
 
 extern "C" {

--- a/R-TypeGame/Systems/Menus/Buttons/PortTextBox/PortTextBoxInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/PortTextBox/PortTextBoxInitSystem.cpp
@@ -12,10 +12,9 @@
 #include "DrawComponent.hpp"
 #include "TextLimitParser.hpp"
 #include "DefaultTextParser.hpp"
-#include "FontPathComponent.hpp"
 #include "EditableComponent.hpp"
-#include "DefaultTextParser.hpp"
 #include "TextLimitComponent.hpp"
+#include "ClickableComponent.hpp"
 #include "ButtonStateComponent.hpp"
 #include "DefaultTextComponent.hpp"
 #include "PortTextBoxInitSystem.hpp"
@@ -71,7 +70,7 @@ void PortTextBoxInitSystem::_initButton(ECS::Registry& reg, int idxPacketEntitie
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 
     std::shared_ptr<EditableComponent> editable = std::make_shared<EditableComponent>();
     reg.register_component<IComponent>(editable->getType());

--- a/R-TypeGame/Systems/Menus/Buttons/SingleplayerButton/SingleplayerButtonInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Buttons/SingleplayerButton/SingleplayerButtonInitSystem.cpp
@@ -34,7 +34,7 @@ void SingleplayerButtonInitSystem::_initButton(ECS::Registry& reg, int idxPacket
         handleOther(reg, idxPacketEntities);
     };
 
-    this->_setButtonProprieties(reg, idxPacketEntities, PATH_JSON, callback);
+    this->_setButtonProperties(reg, idxPacketEntities, PATH_JSON, callback);
 }
 
 extern "C" {

--- a/R-TypeGame/Systems/Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.cpp
+++ b/R-TypeGame/Systems/Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.cpp
@@ -1,0 +1,27 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** ServerConnectionTextInitSystem.cpp
+*/
+
+#include "DrawComponent.hpp"
+#include "ServerConnectionTextInitSystem.hpp"
+
+ServerConnectionTextInitSystem::ServerConnectionTextInitSystem() :
+        ASystem("TextInitSystem")
+{}
+
+void ServerConnectionTextInitSystem::_initText(ECS::Registry &reg, int idxPacketEntities)
+{
+    _setTextProperties(reg, idxPacketEntities, PATH_JSON);
+
+    reg.register_component<IComponent>("DrawComponent");
+    reg.set_component<IComponent>(idxPacketEntities, std::make_shared<DrawComponent>(), "DrawComponent");
+}
+
+extern "C" {
+    EXPORT_SYMBOL ISystem* loadSystemInstance() {
+        return new ServerConnectionTextInitSystem();
+    }
+}

--- a/R-TypeGame/Systems/Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.hpp
+++ b/R-TypeGame/Systems/Menus/Texts/ServerConnection/ServerConnectionTextInitSystem.hpp
@@ -1,0 +1,50 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** ServerConnectionTextInitSystem.hpp
+*/
+
+#pragma once
+
+#include "ATextInitSystem.hpp"
+#include "ISystem.hpp"
+
+#define PATH_JSON "GameData/Scenes/Menus/Texts/serverConnectionTextSystem.json"
+
+/**
+ * @brief ServerConnectionTextInitSystem class
+ *
+ */
+class ServerConnectionTextInitSystem : public ATextInitSystem, public ASystem {
+
+    public:
+
+        /**
+         * @brief Construct a new ServerConnectionTextInitSystem object
+         *
+         */
+        ServerConnectionTextInitSystem();
+
+        /**
+         * @brief Destroy the ServerConnectionTextInitSystem object
+         *
+         */
+        ~ServerConnectionTextInitSystem() = default;
+
+        /**
+         * @brief Get the Function object.
+         *
+         * @return std::function<void(ECS::Registry& reg, int idxPacketEntities)>
+         */
+        std::function<void(ECS::Registry &reg, int idxPacketEntities)> getFunction()
+        {
+            return [this](ECS::Registry& reg, int idxPacketEntities) {
+                _initText(reg, idxPacketEntities);
+            };
+        }
+
+    private:
+
+        void _initText(ECS::Registry& reg, int idxPacketEntities); //< Function to init the text.
+};


### PR DESCRIPTION
I added a temporary menu containing all the buttons described in the linked issue : #210 

To test by yourself and see this menu, you can just change this line in the `ClientSceneManager.cpp` file:
![image](https://github.com/user-attachments/assets/18da59e0-7390-49f9-bfd3-a1ca1d93d707)


The scene looks like this:
![image](https://github.com/user-attachments/assets/df8b385e-3efd-4687-9ddf-687cd48b39c9)

