### PR TITLE
FEAT: Clocked run systems and event listener in game Engines

### DIFF
--- a/Engine/Client/Src/Application/Application.cpp
+++ b/Engine/Client/Src/Application/Application.cpp
@@ -49,13 +49,24 @@ void Application::run()
         _keyboardHandler(_libGraphic->getKeyDownInput());
         _libGraphic->updateMusic();
         _libGraphic->startDraw();
-        _libGraphic->clear();
-        _registry->run_systems(CLIENT);
-        for (auto defaultSystem : _defaultSystems)
-            defaultSystem(*_registry, -1);
-        _eventListener->listen();
-        _libGraphic->endDraw();
+        _runSystems();
     }
+}
+
+void Application::_runSystems()
+{
+    static std::chrono::high_resolution_clock::time_point lastCall = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
+    double timeElapsed = std::chrono::duration<double, std::milli>(now - lastCall).count() / 1000;
+    if (timeElapsed < 0.005)
+        return;
+    _libGraphic->clear();
+    _registry->run_systems(CLIENT);
+    for (auto defaultSystem : _defaultSystems)
+        defaultSystem(*_registry, -1);
+    _eventListener->listen();
+    _libGraphic->endDraw();
+    lastCall = std::chrono::high_resolution_clock::now();
 }
 
 void Application::_sendMessages()

--- a/Engine/Client/Src/Application/Application.hpp
+++ b/Engine/Client/Src/Application/Application.hpp
@@ -144,6 +144,12 @@ class Application {
          */
         void _sendMessages();
 
+        /**
+         * @brief Run all systems and defaults systems of the registry.
+         * This method is clocked to be frame rate dependent.
+         */
+        void _runSystems();
+
 
         std::shared_ptr<ECS::Registry>                                              _registry;          // Registries for each scene.
         std::vector<std::function<void(ECS::Registry& reg, int idxPacketEntities)>> _defaultSystems;    // Default system.

--- a/Engine/Server/Src/GameEngine/Room/Room.cpp
+++ b/Engine/Server/Src/GameEngine/Room/Room.cpp
@@ -41,9 +41,20 @@ void GameEngine::Room::run(std::mutex &mutex)
         _numberPlayers = _roomServer->getNumberClient();
         _packetHandler();
         _connectionHandler();
-        _eventListener->listen();
-        _registries->run_systems(-1);
+        _runSystems();
     }
+}
+
+void GameEngine::Room::_runSystems()
+{
+    static std::chrono::high_resolution_clock::time_point lastCall = std::chrono::high_resolution_clock::now();
+    const std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
+    double timeElapsed = std::chrono::duration<double, std::milli>(now - lastCall).count() / 1000;
+    if (timeElapsed < 0.005)
+        return;
+    _eventListener->listen();
+    _registries->run_systems(SERVER);
+    lastCall = std::chrono::high_resolution_clock::now();
 }
 
 void GameEngine::Room::_sendMessages()

--- a/Engine/Server/Src/GameEngine/Room/Room.hpp
+++ b/Engine/Server/Src/GameEngine/Room/Room.hpp
@@ -104,6 +104,12 @@ class Room {
          */
         void _sendMessages();
 
+        /**
+         * @brief Run all systems of the registry.
+         * This method is clocked to be frame rate dependent.
+         */
+        void _runSystems();
+
         ABINetwork::roomInfo_t  _roomInfos;         // Infos of the room.
         bool                    _isRoomOpen;        // False if the room should close.
         int                     _numberPlayers;     // Number of players in the room.


### PR DESCRIPTION
I clocked the Game Engine to run systems and event listener, they now iterate 200 times per second instead of being CPU dependent.