### PR TITLE
HOTFIX: Fix the segfault of the second game

### DIFF
--- a/QuentinTheFarmerGame/Game/GameData/Scenes/firstScene.json
+++ b/QuentinTheFarmerGame/Game/GameData/Scenes/firstScene.json
@@ -22,9 +22,7 @@
         "libsystem_restartTree.so"
     ],
     "eventHandlers": [
-        "libeventHandler_InitCamera.so",
         "libeventHandler_UpdateCamera.so",
-        "libeventHandler_InitHitBox.so",
         "libeventHandler_DrawHitBoxes.so",
         "libeventHandler_UpdateHitBox.so",
         "libeventHandler_DefaultPlayMusic.so",


### PR DESCRIPTION
I fixed the segfault which was due to not existing handlers in the second game