### PR TITLE
Hotfix: Comment crash on windows

### DIFF
--- a/Engine/Client/Src/Application/Application.cpp
+++ b/Engine/Client/Src/Application/Application.cpp
@@ -143,7 +143,7 @@ void Application::_handleJoinRoomPacket(ABINetwork::UDPPacket packet)
         return;
     }
     _client = room;
-    _eventListener->setNetworkUnit(_client);
+    //_eventListener->setNetworkUnit(_client);
     ABINetwork::sendPacketInit(_client);
     ABINetwork::sendPacketInit(_client);
     ABINetwork::sendMessages(_client);


### PR DESCRIPTION
When connecting the client to the server on Windows, and creating a room, the client was crashing. Commenting the line is fixing this issue